### PR TITLE
Fix "no escapechar set" error

### DIFF
--- a/mysqldump_to_csv.py
+++ b/mysqldump_to_csv.py
@@ -49,7 +49,7 @@ def parse_values(values, outfile):
                         strict=True
     )
 
-    writer = csv.writer(outfile, quoting=csv.QUOTE_MINIMAL)
+    writer = csv.writer(outfile, quoting=csv.QUOTE_MINIMAL, escapechar='\\')
     for reader_row in reader:
         for column in reader_row:
             # If our current string is empty...


### PR DESCRIPTION
If there is a special symbol in the SQL dump, csv writer will throw "_csv.Error: need to escape, but no escapechar set"